### PR TITLE
NTL: reference NTL relative to HEAAN

### DIFF
--- a/HEAAN/lib/src/subdir.mk
+++ b/HEAAN/lib/src/subdir.mk
@@ -56,7 +56,7 @@ CPP_DEPS += \
 src/%.o: ../src/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C++ Compiler'
-	clang++-10 -I/usr/local/include -O3 -g -ggdb -fno-omit-frame-pointer -c -std=c++11 -pthread -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
+	clang++-10 -I/usr/local/include -I../../../ntl/include -I../../../ntl -O3 -g -ggdb -fno-omit-frame-pointer -c -std=c++11 -pthread -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 


### PR DESCRIPTION
Since 'janncy' bring in NTL into the workspace as a dependency, HEAAN
should look for NTL on a relative path instead of expecting to find it
in the distro's library path.

This should be merge together with https://github.com/n-samar/janncy/pull/5.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>